### PR TITLE
Add tool router practice and improve MCP orchestrator

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,75 @@
+# Orchestrator MCP Server
+
+This server follows the Claude cookbooks pattern for an orchestrator MCP tool: it exposes a `consult_specialist` tool that forwards a question to a selected persona, and a `list_personas` tool that advertises the available roles with recommended use cases.
+
+## Configuration
+
+Environment variables control the client and runtime behavior. Defaults are aligned with the cookbook examples.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ANTHROPIC_API_KEY` | _required_ | API key used by the orchestrator to call the model. |
+| `ANTHROPIC_BASE_URL` | `https://api.minimax.io/anthropic` | Base URL for the Anthropic-compatible endpoint. |
+| `ORCHESTRATOR_MODEL` | `MiniMax-M2.1` (fallback to `ANTHROPIC_MODEL` when set) | Model name passed to the client. |
+| `ORCHESTRATOR_TIMEOUT` | `30` | Timeout (seconds) applied to each request. |
+| `ORCHESTRATOR_MAX_TOKENS` | `4096` | Max tokens for responses. |
+| `ORCHESTRATOR_ENABLE_STREAMING` | `false` | When `true`, forces streaming responses. |
+| `ORCHESTRATOR_LOG_LEVEL` | `INFO` | Logging level for structured JSON logs. |
+| `ORCHESTRATOR_ENV_FILE` | `.mcp.json` in repo root | Optional JSON file to preload env values (supports flat object or `mcpServers.orchestrator.env`). |
+
+## Running the server
+
+1. Install dependencies:
+
+   ```bash
+   uv sync
+   ```
+
+2. Export your API key (and any optional overrides) **or** supply them via a JSON file (default `.mcp.json` in the repo root) using the schema in the table above:
+
+   ```bash
+   export ANTHROPIC_API_KEY=sk-...
+   export ORCHESTRATOR_MODEL=claude-3-opus-20240229   # example override
+   ```
+
+3. Start the MCP server (use `python -u` for unbuffered logs; environment variables can also be sourced from your client config such as `.mcp.json` or `settings.json`):
+
+   ```bash
+   python -u mcp-server/orchestrator.py
+   ```
+
+You should see a startup message like:
+
+```
+🚀 Orchestrator Server (Async) starting...
+```
+
+## Registering with an MCP client
+
+Configure your MCP-aware client (e.g., VS Code MCP extension, Claude Desktop) to register this server with the `orchestrator-tools` name and a command that launches the script above. Refer to the [Claude cookbooks orchestrator workflow](https://github.com/anthropics/claude-cookbook/tree/main/mcp#orchestrator-pattern) for client-specific wiring.
+
+## Example calls
+
+1. List available personas (mirrors the persona-selection step from the cookbooks):
+
+   ```json
+   {
+     "tool": "list_personas",
+     "arguments": {}
+   }
+   ```
+
+2. Consult a specialist (matches the consult-specialist pattern):
+
+   ```json
+   {
+     "tool": "consult_specialist",
+     "arguments": {
+       "role": "architect",
+       "query": "Help design a multitenant control plane for internal platform APIs.",
+       "stream": true
+     }
+   }
+   ```
+
+The response will include persona context hints and can stream tokens when `stream` is `true` (or when `ORCHESTRATOR_ENABLE_STREAMING` is enabled).

--- a/mcp-server/orchestrator.py
+++ b/mcp-server/orchestrator.py
@@ -1,10 +1,86 @@
 # mcp-server/orchestrator.py
 import os
 import sys
+import json
 import asyncio
+import logging
+from typing import Any, Dict, List
+
+from anthropic import AsyncAnthropic
 from mcp.server.fastmcp import FastMCP
-from anthropic import AsyncAnthropic  # Key point: Import async client
-from personas import PERSONAS         # Import separated prompts
+
+from personas import PERSONAS
+
+
+def _load_env_from_file() -> Dict[str, str]:
+    """
+    Load environment values from a JSON file if present.
+    Supports:
+    - A flat JSON object of key/value pairs.
+    - A .mcp.json-style file with `mcpServers.orchestrator.env`.
+    """
+    path = os.environ.get("ORCHESTRATOR_ENV_FILE") or os.path.join(os.getcwd(), ".mcp.json")
+    if not os.path.exists(path):
+        return {}
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except Exception as exc:  # pragma: no cover - defensive
+        sys.stderr.write(f"⚠️ Warning: failed to read env file {path}: {exc}\n")
+        return {}
+
+    # Most specific: orchestrator env inside mcpServers
+    orchestrator_env = (
+        data.get("mcpServers", {})
+        .get("orchestrator", {})
+        .get("env", {})
+        if isinstance(data, dict)
+        else {}
+    )
+
+    flat_env = data if isinstance(data, dict) else {}
+
+    merged: Dict[str, str] = {}
+    for source in (flat_env, orchestrator_env):
+        for key, value in source.items():
+            if isinstance(value, str):
+                merged[key] = value
+    return merged
+
+
+_ENV_FILE_VALUES = _load_env_from_file()
+
+
+def _env(key: str, default: str | None = None) -> str | None:
+    """
+    Resolve configuration with precedence:
+    1) JSON file values (ORCHESTRATOR_ENV_FILE or .mcp.json)
+    2) Process environment
+    3) Provided default
+    """
+    return _ENV_FILE_VALUES.get(key) or os.environ.get(key) or default
+
+
+LOG_LEVEL = os.environ.get("ORCHESTRATOR_LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("orchestrator")
+
+
+MODEL = _env("ORCHESTRATOR_MODEL") or _env("ANTHROPIC_MODEL", "MiniMax-M2.1")
+BASE_URL = _env("ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic")
+REQUEST_TIMEOUT = float(_env("ORCHESTRATOR_TIMEOUT", "30"))
+MAX_TOKENS = int(_env("ORCHESTRATOR_MAX_TOKENS", "4096"))
+ENABLE_STREAMING = (_env("ORCHESTRATOR_ENABLE_STREAMING", "false") or "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+API_KEY = _env("ANTHROPIC_API_KEY")
 
 # Initialize MCP Server
 mcp = FastMCP("orchestrator-tools")
@@ -12,60 +88,149 @@ mcp = FastMCP("orchestrator-tools")
 # Startup logs
 sys.stderr.write(f"🚀 Orchestrator Server (Async) starting... PID: {os.getpid()}\n")
 
-# Global Client initialization (connection pool reuse)
-# AsyncAnthropic automatically handles connection pooling, avoiding new connections per call
-api_key = os.environ.get("ANTHROPIC_API_KEY")
-base_url = os.environ.get("ANTHROPIC_BASE_URL", "https://api.minimax.io/anthropic")
-
-if not api_key:
+if not API_KEY:
     sys.stderr.write("⚠️ Warning: ANTHROPIC_API_KEY not found in environment.\n")
 
-client = AsyncAnthropic(api_key=api_key, base_url=base_url)
+client = AsyncAnthropic(api_key=API_KEY, base_url=BASE_URL)
+
+
+def _build_system_prompt(role: str) -> str:
+    persona = PERSONAS[role]
+    hints_section = ""
+    if persona.get("context_hints"):
+        hints = "\n".join(f"- {hint}" for hint in persona["context_hints"])
+        hints_section = f"\nContext hints:\n{hints}\n"
+    description = persona.get("description", "")
+    when_to_use = persona.get("when_to_use", "")
+    return (
+        f"You are {persona.get('name', role)}.\n"
+        f"{description}\n"
+        f"When to use: {when_to_use}\n"
+        f"{hints_section}\n"
+        f"{persona.get('prompt', '')}"
+    )
+
+
+def _serialize_personas() -> List[Dict[str, Any]]:
+    return [
+        {
+            "id": role,
+            "name": details.get("name"),
+            "description": details.get("description"),
+            "when_to_use": details.get("when_to_use"),
+            "context_hints": details.get("context_hints", []),
+        }
+        for role, details in PERSONAS.items()
+    ]
+
+
+def _log_decision(event: str, payload: Dict[str, Any]) -> None:
+    logger.info(json.dumps({"event": event, **payload}))
+
+
+async def _call_model(system_prompt: str, query: str, stream: bool) -> str:
+    messages = [{"role": "user", "content": query}]
+    if stream or ENABLE_STREAMING:
+        async with client.messages.stream(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            system=system_prompt,
+            messages=messages,
+        ) as stream_resp:
+            chunks: List[str] = []
+            async for event in stream_resp:
+                if hasattr(event, "type") and event.type == "message_stop":
+                    break
+                if hasattr(event, "delta") and getattr(event.delta, "text", None):
+                    chunks.append(event.delta.text)
+            return "".join(chunks)
+
+    response = await client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=system_prompt,
+        messages=messages,
+    )
+
+    final_text = []
+    for block in response.content:
+        if hasattr(block, "type") and block.type == "text":
+            final_text.append(block.text)
+        elif hasattr(block, "text"):
+            final_text.append(block.text)
+
+    if not final_text:
+        return "Error: Model returned content but no text block found."
+
+    return "\n".join(final_text)
+
 
 @mcp.tool()
-async def consult_specialist(role: str, query: str) -> str:
+async def list_personas() -> str:
+    """
+    List available personas and their recommended use cases.
+    """
+    persona_list = _serialize_personas()
+    _log_decision("list_personas", {"count": len(persona_list)})
+    return json.dumps(persona_list, indent=2)
+
+
+@mcp.tool()
+async def consult_specialist(role: str, query: str, stream: bool = False) -> str:
     """
     Consult a specialized AI expert for a specific domain task (Async Optimized).
 
     Args:
         role: The role to consult. Options: 'architect', 'platform_expert', 'devops_mlops', 'sre'.
         query: The specific question, code snippet, or design problem to analyze.
+        stream: Whether to request a streaming response from the model.
     """
     # 1. Validate inputs
     if role not in PERSONAS:
-        return f"Error: Role '{role}' not found. Available roles: {list(PERSONAS.keys())}"
-    
-    if not api_key:
-        return "Error: ANTHROPIC_API_KEY is missing."
-
-    system_prompt = PERSONAS[role]
-
-    try:
-        # 2. Async API call (Non-blocking I/O)
-        # The await here releases control, allowing the server to handle other requests concurrently (e.g., heartbeats, cancellations)
-        response = await client.messages.create(
-            model="MiniMax-M2.1",
-            max_tokens=4096,
-            system=system_prompt,
-            messages=[{"role": "user", "content": query}]
+        available = ", ".join(PERSONAS.keys())
+        return (
+            f"Invalid role '{role}'. Choose one of: {available}. "
+            "You can call list_personas for details."
         )
 
-        # 3. Process response
-        final_text = []
-        for block in response.content:
-            if hasattr(block, 'type') and block.type == 'text':
-                final_text.append(block.text)
-            elif hasattr(block, 'text'):
-                final_text.append(block.text)
+    if not API_KEY:
+        return (
+            "Error: ANTHROPIC_API_KEY is missing. "
+            "Set it in your environment to enable consult_specialist."
+        )
 
-        if not final_text:
-            return "Error: Model returned content but no text block found."
+    system_prompt = _build_system_prompt(role)
+    _log_decision(
+        "consult_specialist.request",
+        {"role": role, "stream": stream or ENABLE_STREAMING, "model": MODEL},
+    )
 
-        return f"--- 🤖 Expert Opinion: {role.upper()} ---\n" + "\n".join(final_text)
+    try:
+        response_text = await asyncio.wait_for(
+            _call_model(system_prompt, query, stream=stream), timeout=REQUEST_TIMEOUT
+        )
+        _log_decision(
+            "consult_specialist.success",
+            {"role": role, "stream": stream or ENABLE_STREAMING},
+        )
+        return f"--- 🤖 Expert Opinion: {role.upper()} ---\n{response_text}"
 
-    except Exception as e:
-        sys.stderr.write(f"❌ API Call Error: {str(e)}\n")
-        return f"Error consulting specialist: {str(e)}"
+    except asyncio.TimeoutError:
+        _log_decision(
+            "consult_specialist.timeout",
+            {"role": role, "timeout_seconds": REQUEST_TIMEOUT},
+        )
+        return (
+            f"Request timed out after {REQUEST_TIMEOUT} seconds. "
+            "Try reducing the query size or increasing ORCHESTRATOR_TIMEOUT."
+        )
+    except Exception as exc:
+        _log_decision(
+            "consult_specialist.error",
+            {"role": role, "error": str(exc)},
+        )
+        return f"Error consulting specialist: {exc}"
+
 
 if __name__ == "__main__":
     mcp.run()

--- a/mcp-server/personas.py
+++ b/mcp-server/personas.py
@@ -1,7 +1,16 @@
 # mcp-server/personas.py
 
 PERSONAS = {
-    "architect": """
+    "architect": {
+        "name": "Principal Software Architect",
+        "description": "Guides high-level system design, domain boundaries, and technology trade-offs.",
+        "when_to_use": "Use when framing system architecture, decomposing domains, or validating platform choices.",
+        "context_hints": [
+            "Ask for reasoning about coupling/cohesion and domain-driven boundaries.",
+            "Highlight migration strategies and integration risks.",
+            "Prefer crisp diagrams, interfaces, and data contracts over code-heavy responses."
+        ],
+        "prompt": """
 You are a Principal Software Architect.
 Your focus is on high-level system design, domain boundaries, and technical trade-offs.
 - Analyze requirements from a strategic perspective.
@@ -9,8 +18,18 @@ Your focus is on high-level system design, domain boundaries, and technical trad
 - Make decisions on technology stacks and architectural patterns (Microservices, Monolith, Serverless).
 - Do not get bogged down in implementation details unless necessary for the design.
 """,
+    },
 
-    "platform_expert": """
+    "platform_expert": {
+        "name": "Platform Engineering Expert",
+        "description": "Builds internal developer platforms and reliable infrastructure abstractions.",
+        "when_to_use": "Use for questions about paved paths, IaC, and developer experience on Kubernetes or cloud.",
+        "context_hints": [
+            "Expect guidance on Nix, Terraform, Crossplane, Helm, and multi-tenant clusters.",
+            "Asks clarifying questions about golden paths and self-service guardrails.",
+            "Keeps solutions observable and operable by default."
+        ],
+        "prompt": """
 You are a Platform Engineering Expert.
 Your goal is to build the Internal Developer Platform (IDP) and underlying infrastructure.
 - Focus on Infrastructure as Code (Nix, Terraform, Crossplane).
@@ -18,8 +37,18 @@ Your goal is to build the Internal Developer Platform (IDP) and underlying infra
 - Prioritize developer experience (DX) and self-service capabilities.
 - Ensure the underlying compute/storage/networking is abstracted correctly.
 """,
+    },
 
-    "devops_mlops": """
+    "devops_mlops": {
+        "name": "DevOps & MLOps Expert",
+        "description": "Automates software and data lifecycles with reproducible pipelines and guardrails.",
+        "when_to_use": "Use when designing CI/CD, artifact promotion, or ML experiment/serving workflows.",
+        "context_hints": [
+            "References GitHub Actions, Lefthook, and supply chain security checks.",
+            "Defaults to Nix for reproducibility and immutable builds.",
+            "Connects model training steps to observability and rollout strategies."
+        ],
+        "prompt": """
 You are a DevOps & MLOps Expert.
 Your focus is on the automation of the software and data lifecycles.
 - Design CI/CD pipelines (GitHub Actions, Lefthook).
@@ -27,13 +56,24 @@ Your focus is on the automation of the software and data lifecycles.
 - For MLOps: Focus on model training pipelines, experiment tracking, and model serving.
 - Automate everything: testing, linting, packaging, and deployment.
 """,
+    },
 
-    "sre": """
+    "sre": {
+        "name": "Site Reliability Engineer",
+        "description": "Champions reliability, scalability, and observability for production systems.",
+        "when_to_use": "Use when shaping SLIs/SLOs, incident readiness, or capacity/latency trade-offs.",
+        "context_hints": [
+            "Frames answers with error budgets, runbooks, and graceful degradation patterns.",
+            "Emphasizes tracing/logging/metrics with Prometheus, Grafana, and OpenTelemetry.",
+            "Considers safety valves: circuit breakers, retries with jitter, rate limits."
+        ],
+        "prompt": """
 You are a Site Reliability Engineer (SRE).
 Your priority is reliability, scalability, and observability.
 - Think in terms of SLIs, SLOs, and Error Budgets.
 - Design for failure: circuit breakers, retries, rate limiting.
 - Focus on Observability: Logging, Metrics, Tracing (Prometheus, Grafana, OpenTelemetry).
 - Review code for potential performance bottlenecks and security risks.
-"""
+""",
+    },
 }

--- a/tool-router/README.md
+++ b/tool-router/README.md
@@ -1,0 +1,45 @@
+# Tool Router Practice
+
+This folder holds a Claude tool-router practice set plus a small driver script. It mirrors the cookbook pattern where the router is asked to choose a tool ID, justify the pick, and emit a structured JSON decision.
+
+## JSONL schema (`data/examples/nix.edit.jsonl`)
+
+Each line is a JSON object with the following fields:
+
+| Field | Description | Maps to cookbook router examples |
+| --- | --- | --- |
+| `id` | Unique tool identifier to select. | Tool name/ID exposed to the router. |
+| `intent` | One-line task summary the router should solve. | Equivalent to the user's task description the router reads. |
+| `syntax_focus` | Key syntax or APIs that must be present. | Guidance for the router's tool definitions, similar to cookbook tool capabilities. |
+| `do_not` | Explicit anti-patterns the tool must avoid. | Negative constraints in router tool cards. |
+| `allowed_edits` | Positive permissions/examples of valid edits. | What the tool is allowed to do, mirroring cookbook “capabilities” lists. |
+| `checks` | Required commands/tests to run after edits. | Maps to cookbook “post-call checks” bullets. |
+| `notes` | Additional clarifications or edge cases. | Extra nuance in the tool card description. |
+
+Some entries add `before`/`after`/`example` snippets to showcase the intended change; these act like the cookbook “usage examples” that help the router disambiguate similar tools.
+
+## Running the router example
+
+The `run_router_example.py` script loads `data/examples/nix.edit.jsonl`, builds tool cards from the schema above, and asks the model to pick the best tool for each task—just like the Claude cookbooks router chapter.
+
+```bash
+python tool-router/run_router_example.py \
+  --model claude-3-5-sonnet-20240620 \
+  --dataset tool-router/data/examples/nix.edit.jsonl
+```
+
+The script logs structured routing decisions (JSON with `chosen_tool`, `confidence`, and `reasoning`) and prints an accuracy summary over the sample set so you can practice routing locally.
+
+### Environment
+
+- `ANTHROPIC_API_KEY` must be set.
+- Optional: `ANTHROPIC_BASE_URL` to point at an Anthropic-compatible endpoint.
+
+### What the script does
+
+1. Reads the JSONL dataset and turns each row into a tool card mirroring the cookbook router definitions (capabilities, “avoid” clauses, and example snippets).
+2. Builds a routing prompt that lists all tool cards and instructs the model to reply with JSON: `{\"tool_id\": \"...\", \"confidence\": 0-1, \"reasoning\": \"...\"}`.
+3. Calls the model for each example, logs the response, and compares `tool_id` to the row’s `id` to compute simple accuracy.
+4. Prints per-item routing logs plus an aggregate score.
+
+Use this to rehearse the orchestrator/router pattern before wiring it into the MCP stack.

--- a/tool-router/run_router_example.py
+++ b/tool-router/run_router_example.py
@@ -1,0 +1,172 @@
+import argparse
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from anthropic import Anthropic
+
+
+DEFAULT_MODEL = "claude-3-5-sonnet-20240620"
+LOGGER = logging.getLogger("tool_router")
+
+
+@dataclass
+class ToolCard:
+    tool_id: str
+    body: str
+
+
+def load_examples(path: Path) -> List[Dict]:
+    rows: List[Dict] = []
+    with path.open() as f:
+        for line in f:
+            if not line.strip():
+                continue
+            rows.append(json.loads(line))
+    return rows
+
+
+def format_tool_card(example: Dict) -> ToolCard:
+    lines = [
+        f"Tool ID: {example['id']}",
+        f"Intent: {example.get('intent', '').strip()}",
+        f"Syntax focus: {', '.join(example.get('syntax_focus', []))}",
+        f"Allowed edits: {', '.join(example.get('allowed_edits', []))}",
+        f"Do NOT: {', '.join(example.get('do_not', []))}",
+        f"Checks: {', '.join(example.get('checks', []))}",
+    ]
+    if example.get("notes"):
+        lines.append(f"Notes: {example['notes']}")
+    if example.get("before"):
+        lines.append(f"Before: {example['before']}")
+    if example.get("after"):
+        lines.append(f"After: {example['after']}")
+    if example.get("example"):
+        lines.append(f"Example: {example['example']}")
+    return ToolCard(tool_id=example["id"], body="\n".join(lines))
+
+
+def build_messages(example: Dict, cards: List[ToolCard]) -> List[Dict]:
+    """
+    Build Claude-style router prompt following the cookbook pattern:
+    - System: explain routing goal and output schema.
+    - Tool cards: list each tool with capabilities/constraints.
+    - User: provide the task to route.
+    """
+    tool_sections = "\n\n".join(card.body for card in cards)
+    system = (
+        "You are a tool router. Choose the single best tool for the user's task. "
+        "Use the provided tool cards only. Respond with JSON only, no prose: "
+        '{\"tool_id\": \"<id>\", \"confidence\": 0-1, \"reasoning\": \"brief\"}. '
+        "Never invent tools beyond the provided IDs."
+    )
+    user = (
+        f"Task to route:\n{example.get('intent', '').strip()}\n"
+        "Available tools:\n"
+        f"{tool_sections}"
+    )
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def route_example(
+    client: Anthropic, model: str, example: Dict, cards: List[ToolCard]
+) -> Tuple[str, float, str]:
+    messages = build_messages(example, cards)
+    LOGGER.debug("Routing example %s", example["id"])
+    response = client.messages.create(model=model, max_tokens=256, messages=messages)
+    raw_text = "".join(block.text for block in response.content if hasattr(block, "text"))
+    try:
+        parsed = json.loads(raw_text)
+        tool_id = parsed.get("tool_id", "").strip()
+        confidence = float(parsed.get("confidence", 0))
+        reasoning = parsed.get("reasoning", "")
+    except Exception:
+        tool_id = raw_text.strip()
+        confidence = 0.0
+        reasoning = "Failed to parse JSON response."
+    LOGGER.info(
+        json.dumps(
+            {
+                "example_id": example["id"],
+                "chosen_tool": tool_id,
+                "confidence": confidence,
+                "reasoning": reasoning,
+            }
+        )
+    )
+    return tool_id, confidence, reasoning
+
+
+def evaluate(dataset: List[Dict], model: str, base_url: Optional[str]) -> None:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY is required to run routing.")
+
+    client_kwargs = {"api_key": api_key}
+    if base_url:
+        client_kwargs["base_url"] = base_url
+    client = Anthropic(**client_kwargs)
+    cards = [format_tool_card(row) for row in dataset]
+    correct = 0
+    for example in dataset:
+        chosen, confidence, _ = route_example(client, model, example, cards)
+        expected = example["id"]
+        is_correct = chosen == expected
+        correct += int(is_correct)
+        LOGGER.info(
+            json.dumps(
+                {
+                    "example_id": example["id"],
+                    "expected": expected,
+                    "chosen": chosen,
+                    "confidence": confidence,
+                    "correct": is_correct,
+                }
+            )
+        )
+    accuracy = correct / len(dataset) if dataset else 0
+    print(f"Accuracy: {accuracy:.2%} ({correct}/{len(dataset)})")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run tool-router practice set.")
+    parser.add_argument(
+        "--dataset",
+        type=Path,
+        default=Path("tool-router/data/examples/nix.edit.jsonl"),
+        help="Path to JSONL dataset.",
+    )
+    parser.add_argument(
+        "--model",
+        default=DEFAULT_MODEL,
+        help="Model name to use (Claude-compatible).",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Optional Anthropic-compatible base URL.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        help="Logging level (DEBUG, INFO, etc).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+    dataset = load_examples(args.dataset)
+    base_url = args.base_url or os.environ.get("ANTHROPIC_BASE_URL")
+    evaluate(dataset, args.model, base_url)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add tool-router README plus a routing practice script that builds cookbook-style prompts and reports accuracy over the sample JSONL set
- enhance the MCP orchestrator with env-driven config, structured logging, timeouts, streaming responses, and persona listing/validation that include contextual hints
- document running and wiring the orchestrator MCP server in the context of the Claude cookbooks workflow, recommending `python -u`, inheriting the model from `ORCHESTRATOR_MODEL` or `ANTHROPIC_MODEL`, and supporting env loading from a JSON file (e.g., `.mcp.json`)

## Testing
- python -m compileall mcp-server tool-router

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695442718e8c8328be730cedb51f5271)