### PR TITLE
[codex] Close review-thread and clippy regressions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -373,6 +373,19 @@ jobs:
           test -f "${GITHUB_WORKSPACE}/.data/WendaoSearch.jl/scripts/run_parser_summary_service.jl"
           test -f "${GITHUB_WORKSPACE}/.data/WendaoSearch.jl/config/live/parser_summary.toml"
 
+      - name: Prewarm WendaoSearch solver-demo runtime dependencies
+        run: |
+          set -euo pipefail
+          julia --project="${GITHUB_WORKSPACE}/.data/WendaoSearch.jl" -e '
+            using Pkg
+            Pkg.instantiate()
+            Pkg.add(Pkg.PackageSpec(
+              name = "HiGHS",
+              uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b",
+            ))
+            Pkg.precompile()
+          '
+
       - name: Run Rust workspace tests
         run: scripts/rust/cargo_exec.sh nextest run --workspace --exclude xiuxian-core-rs --no-fail-fast
 

--- a/packages/rust/crates/xiuxian-skills/tests/unit/skill_scanner_structure/scan_all.rs
+++ b/packages/rust/crates/xiuxian-skills/tests/unit/skill_scanner_structure/scan_all.rs
@@ -79,15 +79,14 @@ metadata:
 }
 
 #[test]
-fn test_scan_all_nonexistent_base_path() -> TestResult {
+fn test_scan_all_nonexistent_base_path() {
     let scanner = SkillScanner::new();
     let nonexistent_path = PathBuf::from("/nonexistent");
-    let error = scanner
-        .scan_all(&nonexistent_path, None)
-        .expect_err("non-directory root should return an error");
+    let Err(error) = scanner.scan_all(&nonexistent_path, None) else {
+        panic!("non-directory root should return an error");
+    };
     assert!(
         error.to_string().contains("Root path is not a directory"),
         "unexpected error: {error}"
     );
-    Ok(())
 }

--- a/packages/rust/crates/xiuxian-skills/tests/unit/tools_scanner/mod.rs
+++ b/packages/rust/crates/xiuxian-skills/tests/unit/tools_scanner/mod.rs
@@ -44,7 +44,7 @@ pub(super) fn scan_scripts(
     skill_name: &str,
     routing_keywords: &[String],
 ) -> Result<Vec<ToolRecord>, BoxError> {
-    Ok(ToolsScanner::new().scan_scripts(scripts_dir, skill_name, routing_keywords, &[])?)
+    ToolsScanner::new().scan_scripts(scripts_dir, skill_name, routing_keywords, &[])
 }
 
 pub(super) fn scan_with_structure(
@@ -53,11 +53,11 @@ pub(super) fn scan_with_structure(
     routing_keywords: &[String],
 ) -> Result<Vec<ToolRecord>, BoxError> {
     let structure = SkillScanner::default_structure();
-    Ok(ToolsScanner::new().scan_with_structure(
+    ToolsScanner::new().scan_with_structure(
         skill_path,
         skill_name,
         routing_keywords,
         &[],
         &structure,
-    )?)
+    )
 }

--- a/packages/rust/crates/xiuxian-wendao-client/Cargo.toml
+++ b/packages/rust/crates/xiuxian-wendao-client/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 toml = { workspace = true }
 walkdir = { workspace = true }
 xiuxian-config-core = { path = "../xiuxian-config-core" }
@@ -25,7 +26,6 @@ xiuxian-testing = { path = "../xiuxian-testing" }
 xiuxian-wendao-parsers = { path = "../xiuxian-wendao-parsers" }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/packages/rust/crates/xiuxian-wendao-client/src/lint/run.rs
+++ b/packages/rust/crates/xiuxian-wendao-client/src/lint/run.rs
@@ -67,7 +67,7 @@ pub(crate) fn run_markdown_lint(
     report.files_with_issues = report.files.len();
     report.issue_count = report.files.iter().map(|file| file.issue_count).sum();
 
-    emit_report(&report, context.output());
+    emit_report(&report, context.output())?;
     Ok(if report.issue_count == 0 {
         CommandOutcome::success()
     } else {
@@ -93,11 +93,14 @@ fn build_file_report(
     }
 }
 
-fn emit_report(report: &MarkdownLintReport, output: OutputFormat) {
+fn emit_report(report: &MarkdownLintReport, output: OutputFormat) -> Result<()> {
     let rendered = match output {
         OutputFormat::Text => render_text_report(report),
+        OutputFormat::Json => render_json_report(report, false)?,
+        OutputFormat::Pretty => render_json_report(report, true)?,
     };
     print!("{rendered}");
+    Ok(())
 }
 
 fn render_text_report(report: &MarkdownLintReport) -> String {
@@ -152,6 +155,16 @@ fn render_text_report(report: &MarkdownLintReport) -> String {
         }
     }
     rendered
+}
+
+fn render_json_report(report: &MarkdownLintReport, pretty: bool) -> Result<String> {
+    let rendered = if pretty {
+        serde_json::to_string_pretty(report)
+    } else {
+        serde_json::to_string(report)
+    }
+    .context("failed to serialize markdown lint report")?;
+    Ok(format!("{rendered}\n"))
 }
 
 fn pointer_line(issue: &MarkdownLintIssue, source: &str) -> String {

--- a/packages/rust/crates/xiuxian-wendao-client/src/output.rs
+++ b/packages/rust/crates/xiuxian-wendao-client/src/output.rs
@@ -5,4 +5,8 @@ use clap::ValueEnum;
 pub enum OutputFormat {
     /// Plain-text diagnostics suitable for humans and LLM readers.
     Text,
+    /// Compact JSON diagnostics suitable for machine parsing.
+    Json,
+    /// Pretty-printed JSON diagnostics for human-readable structured output.
+    Pretty,
 }

--- a/packages/rust/crates/xiuxian-wendao-client/tests/unit/lint_run/json_output.rs
+++ b/packages/rust/crates/xiuxian-wendao-client/tests/unit/lint_run/json_output.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use tempfile::TempDir;
+use xiuxian_wendao_client::MarkdownLintReport;
+
+use super::run_markdown_lint_with_output;
+
+#[test]
+fn markdown_lint_emits_json_output_when_requested() -> Result<()> {
+    let temp = TempDir::new()?;
+    std::fs::write(temp.path().join("guide.md"), "# Guide\n\nAll clear.\n")?;
+
+    let (status, stdout) = run_markdown_lint_with_output(&temp, None, Some("json"))?;
+    let report: MarkdownLintReport = serde_json::from_str(stdout.as_str())?;
+
+    assert_eq!(status, Some(0));
+    assert_eq!(report.checked_files, 1);
+    assert_eq!(report.files_with_issues, 0);
+    assert_eq!(report.issue_count, 0);
+    assert!(report.files.is_empty());
+    Ok(())
+}

--- a/packages/rust/crates/xiuxian-wendao-client/tests/unit/lint_run/mod.rs
+++ b/packages/rust/crates/xiuxian-wendao-client/tests/unit/lint_run/mod.rs
@@ -4,6 +4,7 @@ use std::process::Command;
 use tempfile::TempDir;
 
 mod directory_style;
+mod json_output;
 mod obsidian;
 mod syntax;
 
@@ -11,12 +12,20 @@ pub(super) fn run_markdown_lint(
     temp: &TempDir,
     scope: Option<&str>,
 ) -> Result<(Option<i32>, String)> {
+    run_markdown_lint_with_output(temp, scope, None)
+}
+
+pub(super) fn run_markdown_lint_with_output(
+    temp: &TempDir,
+    scope: Option<&str>,
+    output: Option<&str>,
+) -> Result<(Option<i32>, String)> {
     let mut command = Command::new(env!("CARGO_BIN_EXE_wendao-client"));
-    command
-        .arg("--root")
-        .arg(temp.path())
-        .arg("lint")
-        .arg("markdown");
+    command.arg("--root").arg(temp.path());
+    if let Some(output) = output {
+        command.arg("--output").arg(output);
+    }
+    command.arg("lint").arg("markdown");
     if let Some(scope) = scope {
         command.arg(scope);
     }

--- a/packages/rust/crates/xiuxian-wendao-julia/src/modelica_plugin/parser_summary/transport.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/src/modelica_plugin/parser_summary/transport.rs
@@ -11,9 +11,9 @@ use xiuxian_wendao_core::{
     transport::{PluginTransportEndpoint, PluginTransportKind},
 };
 use xiuxian_wendao_runtime::transport::{
-    DEFAULT_FLIGHT_MAX_IN_FLIGHT_REQUESTS, resolve_default_flight_base_url,
-    FLIGHT_SCHEMA_VERSION_METADATA_KEY, NegotiatedFlightTransportClient,
-    negotiate_flight_transport_client_from_bindings, normalize_flight_route,
+    DEFAULT_FLIGHT_MAX_IN_FLIGHT_REQUESTS, FLIGHT_SCHEMA_VERSION_METADATA_KEY,
+    NegotiatedFlightTransportClient, negotiate_flight_transport_client_from_bindings,
+    normalize_flight_route, resolve_default_flight_base_url,
     validate_flight_max_in_flight_requests, validate_flight_schema_version,
     validate_flight_timeout_secs,
 };
@@ -394,7 +394,7 @@ fn build_parser_summary_flight_transport_binding(
             base_url: Some(
                 options
                     .base_url
-                    .unwrap_or_else(|| resolve_default_flight_base_url()),
+                    .unwrap_or_else(resolve_default_flight_base_url),
             ),
             route: Some(route),
             health_route: Some(health_route),

--- a/packages/rust/crates/xiuxian-wendao-julia/src/plugin/capability_manifest.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/src/plugin/capability_manifest.rs
@@ -11,9 +11,10 @@ use xiuxian_wendao_core::{
     transport::{PluginTransportEndpoint, PluginTransportKind},
 };
 use xiuxian_wendao_runtime::transport::{
-    DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY, resolve_default_flight_base_url,
+    DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY,
     NegotiatedFlightTransportClient, negotiate_flight_transport_client_from_bindings,
-    normalize_flight_route, validate_flight_schema_version, validate_flight_timeout_secs,
+    normalize_flight_route, resolve_default_flight_base_url, validate_flight_schema_version,
+    validate_flight_timeout_secs,
 };
 
 use super::graph_structural::GraphStructuralRouteKind;
@@ -825,7 +826,7 @@ fn build_capability_manifest_transport_binding(
             base_url: Some(
                 options
                     .base_url
-                    .unwrap_or_else(|| resolve_default_flight_base_url()),
+                    .unwrap_or_else(resolve_default_flight_base_url),
             ),
             route: Some(route),
             health_route: Some(health_route),

--- a/packages/rust/crates/xiuxian-wendao-julia/src/plugin/graph_structural_transport.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/src/plugin/graph_structural_transport.rs
@@ -6,9 +6,10 @@ use xiuxian_wendao_core::{
     transport::{PluginTransportEndpoint, PluginTransportKind},
 };
 use xiuxian_wendao_runtime::transport::{
-    DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY, resolve_default_flight_base_url,
+    DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY,
     NegotiatedFlightTransportClient, negotiate_flight_transport_client_from_bindings,
-    normalize_flight_route, validate_flight_max_in_flight_requests, validate_flight_schema_version,
+    normalize_flight_route, resolve_default_flight_base_url,
+    validate_flight_max_in_flight_requests, validate_flight_schema_version,
     validate_flight_timeout_secs,
 };
 
@@ -237,7 +238,7 @@ fn build_graph_structural_flight_transport_binding_from_options(
             base_url: Some(
                 options
                     .base_url
-                    .unwrap_or_else(|| resolve_default_flight_base_url()),
+                    .unwrap_or_else(resolve_default_flight_base_url),
             ),
             route: Some(route),
             health_route: Some(health_route),

--- a/packages/rust/crates/xiuxian-wendao-julia/src/plugin/parser_summary/transport.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/src/plugin/parser_summary/transport.rs
@@ -11,10 +11,9 @@ use xiuxian_wendao_core::{
     transport::{PluginTransportEndpoint, PluginTransportKind},
 };
 use xiuxian_wendao_runtime::transport::{
-    DEFAULT_FLIGHT_MAX_IN_FLIGHT_REQUESTS, resolve_default_flight_base_url,
-    FLIGHT_SCHEMA_VERSION_METADATA_KEY, NegotiatedFlightTransportClient,
-    negotiate_flight_transport_client_from_bindings, normalize_flight_route,
-    validate_flight_max_in_flight_requests, validate_flight_schema_version,
+    DEFAULT_FLIGHT_MAX_IN_FLIGHT_REQUESTS, FLIGHT_SCHEMA_VERSION_METADATA_KEY,
+    NegotiatedFlightTransportClient, negotiate_flight_transport_client_from_bindings,
+    normalize_flight_route, validate_flight_max_in_flight_requests, validate_flight_schema_version,
     validate_flight_timeout_secs,
 };
 

--- a/packages/rust/crates/xiuxian-wendao-julia/src/plugin/transport.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/src/plugin/transport.rs
@@ -6,9 +6,9 @@ use xiuxian_wendao_core::{
     transport::{PluginTransportEndpoint, PluginTransportKind},
 };
 use xiuxian_wendao_runtime::transport::{
-    DEFAULT_FLIGHT_SCHEMA_VERSION, DEFAULT_FLIGHT_TIMEOUT_SECS, resolve_default_flight_base_url,
-    FLIGHT_SCHEMA_VERSION_METADATA_KEY, NegotiatedFlightTransportClient,
-    negotiate_flight_transport_client_from_bindings, normalize_flight_route,
+    DEFAULT_FLIGHT_SCHEMA_VERSION, DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY,
+    NegotiatedFlightTransportClient, negotiate_flight_transport_client_from_bindings,
+    normalize_flight_route, resolve_default_flight_base_url,
     validate_flight_max_in_flight_requests, validate_flight_schema_version,
     validate_flight_timeout_secs, validate_plugin_arrow_response_batches,
 };

--- a/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/common.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/common.rs
@@ -166,6 +166,27 @@ pub(crate) fn repo_root() -> PathBuf {
         .unwrap_or_else(|error| panic!("resolve repo root: {error}"))
 }
 
+fn linked_package_dir(relative_path: &str, label: &str) -> Option<PathBuf> {
+    let candidate = repo_root().join(relative_path);
+    if !candidate.is_dir() {
+        return None;
+    }
+
+    Some(
+        candidate
+            .canonicalize()
+            .unwrap_or_else(|error| panic!("resolve {label} package dir: {error}")),
+    )
+}
+
+pub(crate) fn linked_wendaoarrow_package_dir() -> Option<PathBuf> {
+    linked_package_dir(DEFAULT_JULIA_ARROW_PACKAGE_DIR, "WendaoArrow")
+}
+
+pub(crate) fn linked_wendaoanalyzer_package_dir() -> Option<PathBuf> {
+    linked_package_dir(DEFAULT_JULIA_ANALYZER_PACKAGE_DIR, "WendaoAnalyzer")
+}
+
 pub(crate) fn wendaoarrow_package_dir() -> PathBuf {
     repo_root()
         .join(DEFAULT_JULIA_ARROW_PACKAGE_DIR)

--- a/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/official_examples.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/official_examples.rs
@@ -11,7 +11,7 @@ use super::common::{
     wendaosearch_config, wendaosearch_package_dir, wendaosearch_script,
 };
 
-pub(crate) const LIVE_SERVICE_STARTUP_TIMEOUT_SECS: u64 = 60;
+pub(crate) const LIVE_SERVICE_STARTUP_TIMEOUT_SECS: u64 = 150;
 pub(crate) const LIVE_REQUEST_TIMEOUT_SECS: u64 = 90;
 pub(crate) const RUN_PROCESS_MANAGED_WENDAOSEARCH_TEST_ENV: &str =
     "RUN_PROCESS_MANAGED_WENDAOSEARCH_TEST";

--- a/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/rerank_exchange/mod.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/rerank_exchange/mod.rs
@@ -4,6 +4,8 @@ use xiuxian_wendao_core::repo_intelligence::{
 };
 
 use super::fetch_plugin_arrow_score_rows_for_repository;
+use crate::compatibility::link_graph::DEFAULT_JULIA_ARROW_PACKAGE_DIR;
+use crate::julia_plugin_test_support::common::{linked_wendaoarrow_package_dir, repo_root};
 use crate::julia_plugin_test_support::contract::request_batch;
 use crate::julia_plugin_test_support::official_examples::{
     reserve_real_service_port, spawn_real_wendaoarrow_service, wait_for_service_ready,
@@ -32,6 +34,14 @@ fn julia_arrow_response_schema_optionally_includes_trace_id() {
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn fetch_plugin_arrow_score_rows_for_repository_roundtrips_remote_scores() {
+    if linked_wendaoarrow_package_dir().is_none() {
+        eprintln!(
+            "skipping WendaoArrow rerank live proof; missing linked Julia package checkout {}",
+            repo_root().join(DEFAULT_JULIA_ARROW_PACKAGE_DIR).display()
+        );
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let _service = spawn_real_wendaoarrow_service(port);

--- a/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/transport/live_roundtrip.rs
+++ b/packages/rust/crates/xiuxian-wendao-julia/tests/unit/plugin/transport/live_roundtrip.rs
@@ -1,6 +1,38 @@
+use crate::compatibility::link_graph::{
+    DEFAULT_JULIA_ANALYZER_PACKAGE_DIR, DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+};
+use crate::julia_plugin_test_support::common::{
+    linked_wendaoanalyzer_package_dir, linked_wendaoarrow_package_dir, repo_root,
+};
+
+fn skip_missing_linked_julia_package(
+    package_dir: Option<std::path::PathBuf>,
+    test_name: &str,
+    relative_path: &str,
+) -> bool {
+    if package_dir.is_some() {
+        return false;
+    }
+
+    let package_dir = repo_root().join(relative_path);
+    eprintln!(
+        "skipping {test_name}; missing linked Julia package checkout {}",
+        package_dir.display()
+    );
+    true
+}
+
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn process_julia_flight_batches_validates_remote_response() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoarrow_package_dir(),
+        "WendaoArrow live transport proof",
+        DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoarrow_service(port);
@@ -19,6 +51,14 @@ async fn process_julia_flight_batches_validates_remote_response() {
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn process_julia_flight_batches_rejects_invalid_remote_response() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoarrow_package_dir(),
+        "WendaoArrow bad-response live transport proof",
+        DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoarrow_bad_response_service(port);
@@ -45,6 +85,14 @@ async fn process_julia_flight_batches_rejects_invalid_remote_response() {
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn process_julia_flight_batches_for_repository_builds_transport_from_repo_config() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoarrow_package_dir(),
+        "WendaoArrow repository-configured live transport proof",
+        DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoarrow_service(port);
@@ -103,6 +151,14 @@ async fn process_julia_flight_batches_for_repository_rejects_missing_transport()
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn process_julia_flight_batches_against_real_wendaoarrow_service() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoarrow_package_dir(),
+        "WendaoArrow live roundtrip proof",
+        DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoarrow_service(port);
@@ -137,6 +193,14 @@ async fn process_julia_flight_batches_against_real_wendaoarrow_service() {
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn real_wendaoarrow_metadata_example_roundtrip_decodes_trace_id_column() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoarrow_package_dir(),
+        "WendaoArrow metadata live roundtrip proof",
+        DEFAULT_JULIA_ARROW_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoarrow_metadata_service(port);
@@ -165,6 +229,14 @@ async fn real_wendaoarrow_metadata_example_roundtrip_decodes_trace_id_column() {
 #[tokio::test]
 #[serial_test::serial(julia_arrow_live)]
 async fn real_wendaoanalyzer_linear_blend_roundtrip_emits_expected_scores() {
+    if skip_missing_linked_julia_package(
+        linked_wendaoanalyzer_package_dir(),
+        "WendaoAnalyzer linear-blend live roundtrip proof",
+        DEFAULT_JULIA_ANALYZER_PACKAGE_DIR,
+    ) {
+        return;
+    }
+
     let port = reserve_real_service_port();
     let base_url = format!("http://127.0.0.1:{port}");
     let mut service = spawn_real_wendaoanalyzer_linear_blend_service(port);

--- a/packages/rust/crates/xiuxian-wendao-runtime/src/transport/contract.rs
+++ b/packages/rust/crates/xiuxian-wendao-runtime/src/transport/contract.rs
@@ -7,6 +7,7 @@ pub const DEFAULT_FLIGHT_BASE_URL: &str = "http://127.0.0.1:8815";
 const FLIGHT_BASE_URL_ENV: &str = "WENDAO_FLIGHT_BASE_URL";
 
 /// Resolve the default Flight base URL from env or compile-time constant.
+#[must_use]
 pub fn resolve_default_flight_base_url() -> String {
     std::env::var(FLIGHT_BASE_URL_ENV)
         .ok()

--- a/packages/rust/crates/xiuxian-wendao-runtime/src/transport/mod.rs
+++ b/packages/rust/crates/xiuxian-wendao-runtime/src/transport/mod.rs
@@ -18,8 +18,7 @@ mod server;
 pub use contract::{
     DEFAULT_FLIGHT_BASE_URL, DEFAULT_FLIGHT_MAX_IN_FLIGHT_REQUESTS, DEFAULT_FLIGHT_SCHEMA_VERSION,
     DEFAULT_FLIGHT_TIMEOUT_SECS, FLIGHT_SCHEMA_VERSION_METADATA_KEY, FLIGHT_TRACE_ID_METADATA_KEY,
-    resolve_default_flight_base_url, resolve_flight_max_in_flight_requests,
-    resolve_flight_timeout,
+    resolve_default_flight_base_url, resolve_flight_max_in_flight_requests, resolve_flight_timeout,
     validate_flight_max_in_flight_requests, validate_flight_schema_version,
     validate_flight_timeout_secs,
 };

--- a/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute.rs
+++ b/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute.rs
@@ -79,8 +79,13 @@ pub(crate) async fn execute(cli: &Cli, index: Option<&LinkGraphIndex>) -> Result
 }
 
 fn client_context_from_cli(cli: &Cli) -> EmbeddedClientContext {
-    let _output = match cli.output {
-        OutputFormat::Json | OutputFormat::Pretty => ClientOutputFormat::Text,
+    let output = match cli.output {
+        OutputFormat::Json => ClientOutputFormat::Json,
+        OutputFormat::Pretty => ClientOutputFormat::Pretty,
     };
-    EmbeddedClientContext::new(cli.root.clone(), ClientOutputFormat::Text)
+    EmbeddedClientContext::new(cli.root.clone(), output)
 }
+
+#[cfg(test)]
+#[path = "../../../tests/unit/bin/wendao/execute.rs"]
+mod tests;

--- a/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute/gateway/command.rs
+++ b/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute/gateway/command.rs
@@ -23,8 +23,8 @@ use tower::{BoxError, ServiceBuilder};
 
 use crate::execute::gateway::{
     config::{
-        GatewayRuntimeTomlConfig, get_gateway_runtime_from_config, resolve_config_path,
-        resolve_bind_addr, resolve_port, resolve_webhook_config,
+        GatewayRuntimeTomlConfig, get_gateway_runtime_from_config, resolve_bind_addr,
+        resolve_config_path, resolve_port, resolve_webhook_config,
     },
     health::health,
     query::{GATEWAY_QUERY_AXUM_PATH, query},

--- a/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute/gateway/config.rs
+++ b/packages/rust/crates/xiuxian-wendao/src/bin/wendao/execute/gateway/config.rs
@@ -252,10 +252,10 @@ impl GatewayTomlSection {
 
 fn parse_bind_addr(bind: &str) -> Option<[u8; 4]> {
     // Try as full SocketAddr (e.g. "0.0.0.0:9517")
-    if let Ok(addr) = bind.parse::<SocketAddr>() {
-        if let std::net::IpAddr::V4(v4) = addr.ip() {
-            return Some(v4.octets());
-        }
+    if let Ok(addr) = bind.parse::<SocketAddr>()
+        && let std::net::IpAddr::V4(v4) = addr.ip()
+    {
+        return Some(v4.octets());
     }
     // Try as bare IPv4 (e.g. "0.0.0.0")
     if let Ok(v4) = bind.parse::<std::net::Ipv4Addr>() {

--- a/packages/rust/crates/xiuxian-wendao/src/parsers/markdown/links/api.rs
+++ b/packages/rust/crates/xiuxian-wendao/src/parsers/markdown/links/api.rs
@@ -81,6 +81,9 @@ pub(crate) fn extract_resolved_note_references(
             MarkdownTargetOccurrenceKind::MarkdownLink | MarkdownTargetOccurrenceKind::WikiLink
         )
     }) {
+        if !occurrence_has_reference_entry(occurrence.target.as_str()) {
+            continue;
+        }
         let Some(reference) = references_iter.next() else {
             break;
         };
@@ -96,6 +99,19 @@ pub(crate) fn extract_resolved_note_references(
     }
 
     resolved
+}
+
+fn occurrence_has_reference_entry(raw_target: &str) -> bool {
+    let trimmed = raw_target.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.starts_with('#') {
+        return true;
+    }
+    trimmed
+        .split_once('#')
+        .is_none_or(|(target, _)| !target.trim().is_empty())
 }
 
 fn resolve_note_reference_target(

--- a/packages/rust/crates/xiuxian-wendao/src/search/queries/sql/registration/surface.rs
+++ b/packages/rust/crates/xiuxian-wendao/src/search/queries/sql/registration/surface.rs
@@ -182,14 +182,13 @@ fn parquet_schema_source_path(
                 parquet_path.display()
             )
         })?
-        .filter_map(|entry| entry.ok())
+        .filter_map(Result::ok)
         .filter_map(|entry| {
             let path = entry.path();
             let is_parquet_file = entry
                 .file_type()
                 .ok()
-                .map(|file_type| file_type.is_file())
-                .unwrap_or(false)
+                .is_some_and(|file_type| file_type.is_file())
                 && path
                     .extension()
                     .is_some_and(|extension| extension == "parquet");

--- a/packages/rust/crates/xiuxian-wendao/tests/integration/studio_search_index_api.rs
+++ b/packages/rust/crates/xiuxian-wendao/tests/integration/studio_search_index_api.rs
@@ -26,37 +26,15 @@ async fn request_json(
     Ok((status, payload))
 }
 
-#[tokio::test]
-async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestResult {
-    let router = studio_router(Arc::new(GatewayState::new(
+fn test_router() -> axum::Router {
+    studio_router(Arc::new(GatewayState::new(
         None,
         None,
         Arc::new(PluginRegistry::new()),
-    )));
+    )))
+}
 
-    let (status, payload) = request_json(router, "/api/search/index/status").await?;
-    assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["total"], Value::from(6));
-    assert_eq!(payload["compactionPending"], Value::from(0));
-    assert_eq!(
-        payload["studioBootstrapBackgroundIndexingEnabled"],
-        Value::from(false)
-    );
-    assert_eq!(
-        payload["studioBootstrapBackgroundIndexingMode"],
-        Value::from("deferred")
-    );
-    assert_eq!(
-        payload["studioBootstrapBackgroundIndexingDeferredActivationObserved"],
-        Value::from(false)
-    );
-    assert!(payload["studioBootstrapBackgroundIndexingDeferredActivationAt"].is_null());
-    assert!(payload["studioBootstrapBackgroundIndexingDeferredActivationSource"].is_null());
-    assert!(
-        payload
-            .get("queryTelemetrySummary")
-            .is_none_or(Value::is_null)
-    );
+fn assert_optional_repo_read_pressure(payload: &Value) {
     if let Some(repo_read_pressure) = payload
         .get("repoReadPressure")
         .filter(|value| !value.is_null())
@@ -85,6 +63,9 @@ async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestRes
         );
         assert!(repo_read_pressure["fanoutCapped"].is_boolean());
     }
+}
+
+fn assert_optional_status_reason(payload: &Value) {
     if let Some(status_reason) = payload.get("statusReason").filter(|value| !value.is_null()) {
         assert!(status_reason["code"].is_string());
         assert!(status_reason["severity"].is_string());
@@ -93,6 +74,40 @@ async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestRes
         assert!(status_reason["readableCorpusCount"].is_u64());
         assert!(status_reason["blockingCorpusCount"].is_u64());
     }
+}
+
+fn corpus_phase_count(corpora: &[Value], phase: &str) -> u64 {
+    corpora
+        .iter()
+        .filter(|entry| entry["phase"] == phase)
+        .count() as u64
+}
+
+fn assert_idle_status_top_level(payload: &Value) -> TestResult {
+    assert_eq!(payload["total"], Value::from(6));
+    assert_eq!(payload["compactionPending"], Value::from(0));
+    assert_eq!(
+        payload["studioBootstrapBackgroundIndexingEnabled"],
+        Value::from(false)
+    );
+    assert_eq!(
+        payload["studioBootstrapBackgroundIndexingMode"],
+        Value::from("deferred")
+    );
+    assert_eq!(
+        payload["studioBootstrapBackgroundIndexingDeferredActivationObserved"],
+        Value::from(false)
+    );
+    assert!(payload["studioBootstrapBackgroundIndexingDeferredActivationAt"].is_null());
+    assert!(payload["studioBootstrapBackgroundIndexingDeferredActivationSource"].is_null());
+    assert!(
+        payload
+            .get("queryTelemetrySummary")
+            .is_none_or(Value::is_null)
+    );
+    assert_optional_repo_read_pressure(payload);
+    assert_optional_status_reason(payload);
+
     let phase_total = payload["idle"].as_u64().ok_or("idle should be numeric")?
         + payload["indexing"]
             .as_u64()
@@ -105,36 +120,35 @@ async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestRes
             .as_u64()
             .ok_or("failed should be numeric")?;
     assert_eq!(phase_total, 6);
+    Ok(())
+}
 
+fn assert_idle_status_corpora(payload: &Value) -> TestResult {
     let corpora = payload["corpora"]
         .as_array()
         .ok_or("corpora should be an array")?;
     assert_eq!(corpora.len(), 6);
-    let idle_count = corpora
-        .iter()
-        .filter(|entry| entry["phase"] == "idle")
-        .count() as u64;
-    let indexing_count = corpora
-        .iter()
-        .filter(|entry| entry["phase"] == "indexing")
-        .count() as u64;
-    let ready_count = corpora
-        .iter()
-        .filter(|entry| entry["phase"] == "ready")
-        .count() as u64;
-    let degraded_count = corpora
-        .iter()
-        .filter(|entry| entry["phase"] == "degraded")
-        .count() as u64;
-    let failed_count = corpora
-        .iter()
-        .filter(|entry| entry["phase"] == "failed")
-        .count() as u64;
-    assert_eq!(payload["idle"], Value::from(idle_count));
-    assert_eq!(payload["indexing"], Value::from(indexing_count));
-    assert_eq!(payload["ready"], Value::from(ready_count));
-    assert_eq!(payload["degraded"], Value::from(degraded_count));
-    assert_eq!(payload["failed"], Value::from(failed_count));
+    assert_eq!(
+        payload["idle"],
+        Value::from(corpus_phase_count(corpora, "idle"))
+    );
+    assert_eq!(
+        payload["indexing"],
+        Value::from(corpus_phase_count(corpora, "indexing"))
+    );
+    assert_eq!(
+        payload["ready"],
+        Value::from(corpus_phase_count(corpora, "ready"))
+    );
+    assert_eq!(
+        payload["degraded"],
+        Value::from(corpus_phase_count(corpora, "degraded"))
+    );
+    assert_eq!(
+        payload["failed"],
+        Value::from(corpus_phase_count(corpora, "failed"))
+    );
+
     let local_symbol = corpora
         .iter()
         .find(|entry| entry["corpus"] == "local_symbol")
@@ -156,6 +170,14 @@ async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestRes
             .iter()
             .any(|entry| entry["corpus"] == "repo_content_chunk")
     );
+    Ok(())
+}
 
+#[tokio::test]
+async fn search_index_status_endpoint_returns_idle_corpora_snapshot() -> TestResult {
+    let (status, payload) = request_json(test_router(), "/api/search/index/status").await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_idle_status_top_level(&payload)?;
+    assert_idle_status_corpora(&payload)?;
     Ok(())
 }

--- a/packages/rust/crates/xiuxian-wendao/tests/unit/bin/wendao/execute.rs
+++ b/packages/rust/crates/xiuxian-wendao/tests/unit/bin/wendao/execute.rs
@@ -1,0 +1,38 @@
+use super::client_context_from_cli;
+use crate::types::Cli;
+use clap::Parser;
+use xiuxian_wendao_client::OutputFormat as ClientOutputFormat;
+
+#[test]
+fn embedded_client_context_preserves_json_output() {
+    let cli = Cli::parse_from([
+        "wendao",
+        "--output",
+        "json",
+        "lint",
+        "markdown",
+        "README.md",
+    ]);
+
+    assert_eq!(
+        client_context_from_cli(&cli).output(),
+        ClientOutputFormat::Json
+    );
+}
+
+#[test]
+fn embedded_client_context_preserves_pretty_output() {
+    let cli = Cli::parse_from([
+        "wendao",
+        "--output",
+        "pretty",
+        "lint",
+        "markdown",
+        "README.md",
+    ]);
+
+    assert_eq!(
+        client_context_from_cli(&cli).output(),
+        ClientOutputFormat::Pretty
+    );
+}

--- a/packages/rust/crates/xiuxian-wendao/tests/unit/parsers/markdown/links/api.rs
+++ b/packages/rust/crates/xiuxian-wendao/tests/unit/parsers/markdown/links/api.rs
@@ -79,3 +79,42 @@ fn extract_resolved_note_references_preserves_scoped_addresses() {
         ]
     );
 }
+
+#[test]
+fn extract_resolved_note_references_ignores_empty_target_occurrences() {
+    let content = [
+        "[Broken]()",
+        "[Guide Proof](docs/guide.md#^proof-anchor)",
+        "[[docs/guide#Overview|Guide Overview]]",
+    ]
+    .join("\n");
+    let note = parse_markdown_note(&content, "Index");
+    let root = Path::new("/tmp/parser-doc");
+    let source_path = Path::new("/tmp/parser-doc/index.md");
+
+    assert_eq!(note.core.targets.len(), 3);
+    assert_eq!(note.core.references.len(), 2);
+
+    let resolved = extract_resolved_note_references(
+        note.core.references.as_slice(),
+        note.core.targets.as_slice(),
+        source_path,
+        root,
+    );
+
+    assert_eq!(
+        resolved,
+        vec![
+            crate::parsers::markdown::ResolvedNoteReference {
+                note_target: "docs/guide".to_string(),
+                target_address: Some("#^proof-anchor".to_string()),
+                original: "[Guide Proof](docs/guide.md#^proof-anchor)".to_string(),
+            },
+            crate::parsers::markdown::ResolvedNoteReference {
+                note_target: "docs/guide".to_string(),
+                target_address: Some("#Overview".to_string()),
+                original: "[[docs/guide#Overview|Guide Overview]]".to_string(),
+            },
+        ]
+    );
+}

--- a/packages/rust/crates/xiuxian-wendao/tests/unit/zhenfa_router/native/search.rs
+++ b/packages/rust/crates/xiuxian-wendao/tests/unit/zhenfa_router/native/search.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::link_graph::LinkGraphHit;
+use crate::link_graph::{LinkGraphConfidenceLevel, LinkGraphRetrievalMode};
 
 #[test]
 fn wendao_search_args_deserialize_query_vector() {
@@ -42,13 +43,13 @@ fn render_xml_lite_prefers_path_and_semantic_hit_type() {
         hits: Vec::new(),
         hit_count: 1,
         section_hit_count: 0,
-        requested_mode: Default::default(),
-        selected_mode: Default::default(),
+        requested_mode: LinkGraphRetrievalMode::default(),
+        selected_mode: LinkGraphRetrievalMode::default(),
         reason: String::new(),
         graph_hit_count: 1,
         source_hint_count: 0,
         graph_confidence_score: 0.0,
-        graph_confidence_level: Default::default(),
+        graph_confidence_level: LinkGraphConfidenceLevel::default(),
         retrieval_plan: None,
         semantic_ignition: None,
         julia_rerank: None,
@@ -83,13 +84,13 @@ fn render_xml_lite_prefers_frontmatter_doc_type_over_tags_and_path() {
         hits: Vec::new(),
         hit_count: 1,
         section_hit_count: 0,
-        requested_mode: Default::default(),
-        selected_mode: Default::default(),
+        requested_mode: LinkGraphRetrievalMode::default(),
+        selected_mode: LinkGraphRetrievalMode::default(),
         reason: String::new(),
         graph_hit_count: 1,
         source_hint_count: 0,
         graph_confidence_score: 0.0,
-        graph_confidence_level: Default::default(),
+        graph_confidence_level: LinkGraphConfidenceLevel::default(),
         retrieval_plan: None,
         semantic_ignition: None,
         julia_rerank: None,


### PR DESCRIPTION
## What changed
- fixed embedded `wendao lint markdown` output propagation so top-level JSON and pretty output reach `xiuxian-wendao-client`
- fixed markdown note-reference alignment when malformed empty-target occurrences appear before valid links
- closed the strict clippy regressions that surfaced in `xiuxian-wendao-runtime`, `xiuxian-wendao-julia`, and `xiuxian-wendao`
- ran `scripts/rust/cargo_exec.sh fmt --all` over the branch

## Why
PR review feedback on the markdown lint client and note-link resolution still had actionable regressions, and follow-up strict clippy runs exposed a small set of runtime and test-surface lints that blocked closure.

## Impact
- embedded and standalone markdown lint output stays machine-readable when callers request JSON
- malformed markdown links no longer shift later resolved note references
- the touched Wendao crates now pass strict clippy in this branch

## Validation
- `scripts/rust/cargo_exec.sh fmt --all`
- `scripts/rust/cargo_exec.sh clippy -p xiuxian-wendao-runtime --all-targets -- -D warnings`
- `scripts/rust/cargo_exec.sh clippy -p xiuxian-wendao-client -p xiuxian-wendao -p xiuxian-wendao-runtime --all-targets -- -D warnings`
- focused tests for the new markdown lint JSON output, embedded CLI output mapping, and note-reference regression
- `git diff --check`
