### PR TITLE
fix(ci): rely on wendaosearch project deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -393,10 +393,6 @@ jobs:
             )
             Pkg.instantiate()
             Pkg.update("Absyn")
-            Pkg.add(
-              Pkg.PackageSpec(name="HiGHS", uuid="87dc4568-4c63-4d18-b0c0-bb2238e4078b");
-              preserve=Pkg.PRESERVE_ALL,
-            )
             Pkg.precompile()
             using WendaoSearch
             package_dir = dirname(dirname(pathof(WendaoSearch)))

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,15 +372,16 @@ jobs:
           export WENDAOSEARCH_PACKAGE_DIR="${RUNNER_TEMP}/WendaoSearch.jl"
           export WENDAOSEARCH_JULIA_PROJECT="${WENDAOSEARCH_PACKAGE_DIR}"
           export WENDAOSEARCH_PACKAGE_DIR_FILE="${RUNNER_TEMP}/wendaosearch-package-dir.txt"
-          export WENDAOSEARCH_REV=903c9e03ed8da3ed8f71b68cf947eaa20894affc
-          git init "${WENDAOSEARCH_PACKAGE_DIR}"
-          git -C "${WENDAOSEARCH_PACKAGE_DIR}" remote add origin https://github.com/tao3k/WendaoSearch.jl.git
-          git -C "${WENDAOSEARCH_PACKAGE_DIR}" fetch --depth 1 origin "${WENDAOSEARCH_REV}"
-          git -C "${WENDAOSEARCH_PACKAGE_DIR}" checkout --detach FETCH_HEAD
-          test "$(git -C "${WENDAOSEARCH_PACKAGE_DIR}" rev-parse HEAD)" = "${WENDAOSEARCH_REV}"
+          git clone --depth 1 --branch main https://github.com/tao3k/WendaoSearch.jl.git "${WENDAOSEARCH_PACKAGE_DIR}"
+          git -C "${WENDAOSEARCH_PACKAGE_DIR}" rev-parse HEAD
           julia --project="${WENDAOSEARCH_JULIA_PROJECT}" -e '
             using Pkg
+            using TOML
             Pkg.activate(ENV["WENDAOSEARCH_JULIA_PROJECT"])
+            project = TOML.parsefile(joinpath(ENV["WENDAOSEARCH_JULIA_PROJECT"], "Project.toml"))
+            deps = get(project, "deps", Dict{String,Any}())
+            haskey(deps, "HiGHS") ||
+              error("WendaoSearch main Project.toml must declare HiGHS for solver_demo runtime")
             function ensure_registry(name::String; spec=nothing)
               registries = Pkg.Registry.reachable_registries()
               any(registry -> registry.name == name, registries) && return

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -372,7 +372,12 @@ jobs:
           export WENDAOSEARCH_PACKAGE_DIR="${RUNNER_TEMP}/WendaoSearch.jl"
           export WENDAOSEARCH_JULIA_PROJECT="${WENDAOSEARCH_PACKAGE_DIR}"
           export WENDAOSEARCH_PACKAGE_DIR_FILE="${RUNNER_TEMP}/wendaosearch-package-dir.txt"
-          git clone --depth 1 https://github.com/tao3k/WendaoSearch.jl.git "${WENDAOSEARCH_PACKAGE_DIR}"
+          export WENDAOSEARCH_REV=903c9e03ed8da3ed8f71b68cf947eaa20894affc
+          git init "${WENDAOSEARCH_PACKAGE_DIR}"
+          git -C "${WENDAOSEARCH_PACKAGE_DIR}" remote add origin https://github.com/tao3k/WendaoSearch.jl.git
+          git -C "${WENDAOSEARCH_PACKAGE_DIR}" fetch --depth 1 origin "${WENDAOSEARCH_REV}"
+          git -C "${WENDAOSEARCH_PACKAGE_DIR}" checkout --detach FETCH_HEAD
+          test "$(git -C "${WENDAOSEARCH_PACKAGE_DIR}" rev-parse HEAD)" = "${WENDAOSEARCH_REV}"
           julia --project="${WENDAOSEARCH_JULIA_PROJECT}" -e '
             using Pkg
             Pkg.activate(ENV["WENDAOSEARCH_JULIA_PROJECT"])

--- a/scripts/channel/test_wendaosearch_ci_bootstrap.py
+++ b/scripts/channel/test_wendaosearch_ci_bootstrap.py
@@ -19,9 +19,13 @@ def test_ci_bootstraps_wendaosearch_with_julia_pkg() -> None:
         not in workflow
     )
     assert (
-        "git clone --depth 1 https://github.com/tao3k/WendaoSearch.jl.git"
+        "WENDAOSEARCH_REV=903c9e03ed8da3ed8f71b68cf947eaa20894affc" in workflow
+    )
+    assert (
+        'git -C "${WENDAOSEARCH_PACKAGE_DIR}" fetch --depth 1 origin "${WENDAOSEARCH_REV}"'
         in workflow
     )
+    assert 'checkout --detach FETCH_HEAD' in workflow
     assert 'WENDAOSEARCH_JULIA_PROJECT="${WENDAOSEARCH_PACKAGE_DIR}"' in workflow
     assert "WendaoCodeParser" not in workflow
     assert "WendaoArrow" not in workflow

--- a/scripts/channel/test_wendaosearch_ci_bootstrap.py
+++ b/scripts/channel/test_wendaosearch_ci_bootstrap.py
@@ -27,8 +27,6 @@ def test_ci_bootstraps_wendaosearch_with_julia_pkg() -> None:
     assert "WendaoArrow" not in workflow
     assert "Pkg.instantiate()" in workflow
     assert 'Pkg.update("Absyn")' in workflow
-    assert 'Pkg.PackageSpec(name="HiGHS"' in workflow
-    assert "preserve=Pkg.PRESERVE_ALL" in workflow
     assert "WENDAOSEARCH_PACKAGE_DIR" in workflow
     assert (
         "WENDAOSEARCH_CONFIG=${WENDAOSEARCH_PACKAGE_DIR}/config/live/parser_summary.toml"

--- a/scripts/channel/test_wendaosearch_ci_bootstrap.py
+++ b/scripts/channel/test_wendaosearch_ci_bootstrap.py
@@ -18,14 +18,13 @@ def test_ci_bootstraps_wendaosearch_with_julia_pkg() -> None:
         'Pkg.add(Pkg.PackageSpec(url="https://github.com/tao3k/WendaoSearch.jl.git"))'
         not in workflow
     )
+    assert "WENDAOSEARCH_REV" not in workflow
     assert (
-        "WENDAOSEARCH_REV=903c9e03ed8da3ed8f71b68cf947eaa20894affc" in workflow
-    )
-    assert (
-        'git -C "${WENDAOSEARCH_PACKAGE_DIR}" fetch --depth 1 origin "${WENDAOSEARCH_REV}"'
+        "git clone --depth 1 --branch main https://github.com/tao3k/WendaoSearch.jl.git"
         in workflow
     )
-    assert 'checkout --detach FETCH_HEAD' in workflow
+    assert 'git -C "${WENDAOSEARCH_PACKAGE_DIR}" rev-parse HEAD' in workflow
+    assert "WendaoSearch main Project.toml must declare HiGHS" in workflow
     assert 'WENDAOSEARCH_JULIA_PROJECT="${WENDAOSEARCH_PACKAGE_DIR}"' in workflow
     assert "WendaoCodeParser" not in workflow
     assert "WendaoArrow" not in workflow


### PR DESCRIPTION
## Summary\n- remove the temporary CI-side HiGHS Pkg.add workaround\n- keep Rust CI bootstrap limited to cloning WendaoSearch, instantiating its project, updating Absyn, and precompiling\n- update the bootstrap guard so Julia dependency ownership stays in WendaoSearch Project/Manifest\n\n## Julia package follow-ups\n- tao3k/WendaoCodeParser.jl#5 fixes compat for the source-pinned parser graph\n- tao3k/WendaoSearch.jl#5 declares HiGHS as a runtime dependency and refreshes the manifest\n\n## Verification\n- uv run --directory /tmp/xiuxian-ci-slow-fix.mTMs5S pytest scripts/channel/test_wendaosearch_ci_bootstrap.py scripts/channel/test_main_ci_secret_guards.py -q\n- git diff --check origin/main...HEAD